### PR TITLE
Bring examples up to date with latest ReasonJS

### DIFF
--- a/src/logo/logoRoot.re
+++ b/src/logo/logoRoot.re
@@ -1,1 +1,4 @@
-ReactDOMRe.render <Logo message="REASON REACT" /> (ReasonJs.Document.getElementById "index");
+switch (ReasonJs.Document.getElementById "index" ReasonJs.Dom.document) {
+| None => Js.log "Root element 'index' not found on page, unable to start React app"
+| Some el => ReactDOMRe.render <Logo message="REASON REACT" /> el
+};

--- a/src/logo/logoRoot.re
+++ b/src/logo/logoRoot.re
@@ -1,4 +1,4 @@
 switch (ReasonJs.Document.getElementById "index" ReasonJs.Dom.document) {
-| None => Js.log "Root element 'index' not found on page, unable to start React app"
+| None => raise (Invalid_argument "Root element 'index' not found in document")
 | Some el => ReactDOMRe.render <Logo message="REASON REACT" /> el
 };

--- a/src/simple/simpleRoot.re
+++ b/src/simple/simpleRoot.re
@@ -1,6 +1,6 @@
 Js.log "Do you see this message? If you do, then things should work!";
 
 switch (ReasonJs.Document.getElementById "index" ReasonJs.Dom.document) {
-| None => Js.log "Root element 'index' not found on page, unable to start React app"
+| None => raise (Invalid_argument "Root element 'index' not found in document")
 | Some el => ReactDOMRe.render <Page message="Hello!" /> el
 };

--- a/src/simple/simpleRoot.re
+++ b/src/simple/simpleRoot.re
@@ -1,3 +1,6 @@
 Js.log "Do you see this message? If you do, then things should work!";
 
-ReactDOMRe.render <Page message="Hello!" /> (ReasonJs.Document.getElementById "index");
+switch (ReasonJs.Document.getElementById "index" ReasonJs.Dom.document) {
+| None => Js.log "Root element 'index' not found on page, unable to start React app"
+| Some el => ReactDOMRe.render <Page message="Hello!" /> el
+};

--- a/src/todomvc/app.re
+++ b/src/todomvc/app.re
@@ -177,6 +177,6 @@ switch (
   ReasonJs.HtmlCollection.item
     0 (ReasonJs.Document.getElementsByClassName "todoapp" ReasonJs.Dom.document)
 ) {
-| None => Js.log "Unable to find root 'todoapp' element, cannot start React app"
+| None => raise (Invalid_argument "Root element 'todoapp' not found in document")
 | Some el => ReactDOMRe.render <Top /> el
 };

--- a/src/todomvc/todoItem.re
+++ b/src/todomvc/todoItem.re
@@ -1,5 +1,3 @@
-external domAsHtmlElement : ReasonJs.Dom.element => ReasonJs.Dom.htmlElement = "%identity";
-
 let escapeKey = 27;
 
 let enterKey = 13;
@@ -46,9 +44,12 @@ module TodoItem = {
     } else {
       None
     };
-  let handleChange {props} event =>
-    props.editing ?
-      Some {editText: ReasonJs.HtmlElement.value (domAsHtmlElement event##target)} : None;
+  let handleChange {props} (event: ReactRe.event) =>
+    switch (props.editing, ReasonJs.Dom.Element.asHtmlElement event##target) {
+    | (true, Some el) => Some {editText: ReasonJs.HtmlElement.value el}
+    | (true, None) => raise (Failure "Invalid event target passed to todoItem handleChange")
+    | _ => None
+    };
   let setEditFieldRef {instanceVars} r => instanceVars.editFieldRef = Some r;
 
   /**

--- a/src/todomvc/todoItem.re
+++ b/src/todomvc/todoItem.re
@@ -1,3 +1,5 @@
+external domAsHtmlElement : ReasonJs.Dom.element => ReasonJs.Dom.htmlElement = "%identity";
+
 let escapeKey = 27;
 
 let enterKey = 13;
@@ -45,7 +47,8 @@ module TodoItem = {
       None
     };
   let handleChange {props} event =>
-    props.editing ? Some {editText: ReasonJs.Document.value event##target} : None;
+    props.editing ?
+      Some {editText: ReasonJs.HtmlElement.value (domAsHtmlElement event##target)} : None;
   let setEditFieldRef {instanceVars} r => instanceVars.editFieldRef = Some r;
 
   /**


### PR DESCRIPTION
Probably worth having @glennsl taken a look over it (especially the repeated `external domAsHtmlElement : ReasonJs.Dom.element => ReasonJs.Dom.htmlElement = "%identity";`), but this brings all the examples up to date with ReasonJs master