### PR TITLE
Fix deprecated use of React.createClass

### DIFF
--- a/src/interop/interopRoot.js
+++ b/src/interop/interopRoot.js
@@ -4,15 +4,14 @@ var React = require('react');
 // Import a ReasonReact component! `comp` is the exposed, underlying ReactJS class
 var PageReason = require('../../lib/js/src/interop/pageReason').jsComponent;
 
-var App = React.createClass({
-  displayName: 'exampleInteropRoot',
-  render: function() {
-    return React.createElement('div', null,
-      React.createElement(PageReason, {message: 'Hello!'})
-    );
-    // didn't feel like dragging in Babel. Here's the equivalent JSX:
-    // <div><PageReason message="Hello!"></div>
-  }
-});
+var App = function() {
+  return React.createElement('div', null,
+    React.createElement(PageReason, {message: 'Hello!'})
+  );
+  // didn't feel like dragging in Babel. Here's the equivalent JSX:
+  // <div><PageReason message="Hello!"></div>
+}
+;
+App.displayName = 'exampleInteropRoot';
 
 ReactDOM.render(React.createElement(App), document.getElementById('index'));

--- a/src/interop/myBanner.js
+++ b/src/interop/myBanner.js
@@ -1,17 +1,15 @@
 var ReactDOM = require('react-dom');
 var React = require('react');
 
-var App = React.createClass({
-  displayName: "MyBanner",
-  render: function() {
-    if (this.props.show) {
-      return React.createElement('div', null,
-        this.props.message
-      );
-    } else {
-      return null;
-    }
+var App = function(props) {
+  if (props.show) {
+    return React.createElement('div', null,
+      props.message
+    );
+  } else {
+    return null;
   }
-});
+}
+App.displayName = "MyBanner";
 
 module.exports = App;


### PR DESCRIPTION
This fixes the deprecation warnings that were showing up in the console.