### PR TITLE
Add clearInterval when unmount

### DIFF
--- a/src/async/Counter.re
+++ b/src/async/Counter.re
@@ -24,6 +24,12 @@ let make _children => {
     self.state.timerId := Some (Js.Global.setInterval (self.reduce (fun _ => Tick)) 1000);
     ReasonReact.NoUpdate
   },
+  willUnmount: fun {state} => {
+    switch !state.timerId {
+    | Some id => Js.Global.clearInterval id
+    | _  => ()
+    }
+  },
   render: fun {state: {count}} => {
     let timesMessage = count == 1 ? "second" : "seconds";
     let greeting = {j|You've spent $count $timesMessage on this page!|j};


### PR DESCRIPTION
The timer in the Counter component should be cleared when the component is unmounted. 
Even if not a fatal error in this case, since the Counter is never unmounted, it is better to do it properly, not to introduce an error if the component is used in a different manner. This way we also get an example of willUnmount lifecycle hook :-) 