### PR TITLE
Remove trailing comma from bsconfig json file

### DIFF
--- a/bsconfig.json
+++ b/bsconfig.json
@@ -15,7 +15,7 @@
   ],
   "package-specs": {
     "module": "commonjs",
-    "in-source": true,
+    "in-source": true
   },
   "suffix": ".bs.js",
   "refmt": 3


### PR DESCRIPTION
There was a trailing comma in a json file (bsconfig.json)

ps: thank you so much for this repo to help people learn about reason react.